### PR TITLE
Added the Pi 3 Model B to the revisions

### DIFF
--- a/src/Mapping/MapSelector.js
+++ b/src/Mapping/MapSelector.js
@@ -68,6 +68,7 @@ class RevisionMapSelector {
      */
     _loadRevisions() {
         this.addMapForRevision('9000c1', Maps.PiZeroWMap);
+        this.addMapForRevision('a02082', Maps.PiZeroWMap); // Pi Three Model B has the exact same GPIO Header
     }
 
     /**


### PR DESCRIPTION
The Pi 3 Model B has the exact same GPIO Header as the Pi 0 W.
I added the revision and attached the existing map to it.